### PR TITLE
Adapt perf package to our needs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+----
+
+This is a clone of the `golang.org/x/sys/unix/linux/perf` submitted by
+[acln0](https://github.com/acln0) to review at
+https://go-review.googlesource.com/c/sys/+/168059
+
+An alternative working tree for this package can also be found
+at https://github.com/acln0/perf
+
+This Elastic fork contains bugfixes and features necessary for
+our KProbes implementation.
+
+----
+
 `perf` API client package for Linux. See `man 2 perf_event_open` and
 `include/uapi/linux/perf_event.h`.
 

--- a/count.go
+++ b/count.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build linux
+
 package perf
 
 import (

--- a/group.go
+++ b/group.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build linux
+
 package perf
 
 import (

--- a/perf.go
+++ b/perf.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build linux
+
 package perf
 
 import (

--- a/perf.go
+++ b/perf.go
@@ -95,6 +95,11 @@ type Event struct {
 	// pollresp receives responses from the poll goroutine associated
 	// with the ring, back to ReadRawRecord.
 	pollresp chan pollresp
+
+	// recordBuffer is used as storage for records returned by ReadRecord
+	// and ReadRawRecord. This means memory for records returned from those
+	// methods will be overwritten by successive calls.
+	recordBuffer []byte
 }
 
 // Open opens the event configured by attr.

--- a/perf.go
+++ b/perf.go
@@ -129,6 +129,12 @@ func Open(a *Attr, pid, cpu int, group *Event) (*Event, error) {
 	return open(a, pid, cpu, group, 0)
 }
 
+// OpenWithFlags is like Open but allows to specify additional flags to be
+// passed to perf_event_open(2).
+func OpenWithFlags(a *Attr, pid, cpu int, group *Event, flags int) (*Event, error) {
+	return open(a, pid, cpu, group, flags)
+}
+
 // OpenCGroup is like Open, but activates per-container system-wide
 // monitoring. If cgroupfs is mounted on /dev/cgroup, and the group to
 // monitor is called "test", then cgroupfd must be a file descriptor opened

--- a/perf_example_test.go
+++ b/perf_example_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build linux
+
 package perf_test
 
 import (

--- a/perf_test.go
+++ b/perf_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build linux
+
 package perf_test
 
 import (

--- a/record.go
+++ b/record.go
@@ -178,6 +178,11 @@ again:
 	}
 }
 
+// HasRecord returns if there is a record available to be read from the ring.
+func (ev *Event) HasRecord() bool {
+	return atomic.LoadUint64(&ev.meta.Data_head) != atomic.LoadUint64(&ev.meta.Data_tail)
+}
+
 // resetRing advances the read pointer to the write pointer to discard all the
 // data in the ring. This is done when bogus data is read from the ring.
 func (ev *Event) resetRing() {

--- a/record.go
+++ b/record.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build linux
+
 package perf
 
 import (

--- a/record.go
+++ b/record.go
@@ -29,6 +29,9 @@ var ErrDisabled = errors.New("perf: event disabled")
 // events. See also (*Event).SetOutput.
 var ErrNoReadRecord = errors.New("perf: ReadRecord disabled")
 
+// ErrBadRecord is returned by ReadRecord when a read record can't be decoded.
+var ErrBadRecord = errors.New("bad record received")
+
 // ReadRecord reads and decodes a record from the ring buffer associated
 // with ev.
 //
@@ -54,7 +57,9 @@ func (ev *Event) ReadRecord(ctx context.Context) (Record, error) {
 	if err != nil {
 		return nil, err
 	}
-	rec.DecodeFrom(&raw, ev)
+	if err := rec.DecodeFrom(&raw, ev); err != nil {
+		return nil, err
+	}
 	return rec, nil
 }
 
@@ -173,6 +178,12 @@ again:
 	}
 }
 
+// resetRing advances the read pointer to the write pointer to discard all the
+// data in the ring. This is done when bogus data is read from the ring.
+func (ev *Event) resetRing() {
+	atomic.StoreUint64(&ev.meta.Data_tail, atomic.LoadUint64(&ev.meta.Data_head))
+}
+
 // readRawRecordNonblock reads a raw record into rec, if one is available.
 // Callers must not retain rec.Data. The boolean return value signals whether
 // a record was actually found / written to rec.
@@ -183,26 +194,45 @@ func (ev *Event) readRawRecordNonblock(raw *RawRecord) bool {
 		return false
 	}
 
+	// Make sure there is enough space the read a record header. Otherwise
+	// consider the ring to be corrupted.
+	const headerSize = uint64(unsafe.Sizeof(RecordHeader{}))
+	avail := head - tail
+	if avail < headerSize {
+		ev.resetRing()
+		return false
+	}
+
 	// Head and tail values only ever grow, so we must take their value
 	// modulo the size of the data segment of the ring.
 	start := tail % uint64(len(ev.ringdata))
 	raw.Header = *(*RecordHeader)(unsafe.Pointer(&ev.ringdata[start]))
 	end := (tail + uint64(raw.Header.Size)) % uint64(len(ev.ringdata))
 
+	// Make sure there is enough space available to read the whole record.
+	// Otherwise treat the ring as corrupted.
+	msgLen := uint64(raw.Header.Size)
+	if avail < msgLen || msgLen < headerSize {
+		ev.resetRing()
+		return false
+	}
+
+	// Reserve space to store this record out of the ring.
+	if uint64(len(ev.recordBuffer)) < msgLen {
+		ev.recordBuffer = make([]byte, msgLen)
+	}
 	// If the record wraps around the ring, we must allocate storage,
 	// so that we can return a contiguous area of memory to the caller.
-	var data []byte
 	if end < start {
-		data = make([]byte, raw.Header.Size)
-		n := copy(data, ev.ringdata[start:])
-		copy(data[n:], ev.ringdata[:int(raw.Header.Size)-n])
+		n := copy(ev.recordBuffer, ev.ringdata[start:])
+		copy(ev.recordBuffer[n:], ev.ringdata[:int(raw.Header.Size)-n])
 	} else {
-		data = ev.ringdata[start:end]
+		copy(ev.recordBuffer, ev.ringdata[start:end])
 	}
-	raw.Data = data[unsafe.Sizeof(raw.Header):]
+	raw.Data = ev.recordBuffer[unsafe.Sizeof(raw.Header):msgLen]
 
 	// Notify the kernel of the last record we've seen.
-	atomic.AddUint64(&ev.meta.Data_tail, uint64(raw.Header.Size))
+	atomic.AddUint64(&ev.meta.Data_tail, msgLen)
 	return true
 }
 
@@ -390,7 +420,7 @@ type SampleID struct {
 // Record is the interface implemented by all record types.
 type Record interface {
 	Header() RecordHeader
-	DecodeFrom(*RawRecord, *Event)
+	DecodeFrom(*RawRecord, *Event) error
 }
 
 // RecordType is the type of an overflow record.
@@ -521,7 +551,7 @@ type MmapRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (mr *MmapRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (mr *MmapRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	mr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint32(&mr.Pid, &mr.Tid)
@@ -530,6 +560,7 @@ func (mr *MmapRecord) DecodeFrom(raw *RawRecord, ev *Event) {
 	f.uint64(&mr.PageOffset)
 	f.string(&mr.Filename)
 	f.idCond(ev.a.Options.SampleIDAll, &mr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // Executable returns a boolean indicating whether the mapping is executable.
@@ -547,12 +578,13 @@ type LostRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (lr *LostRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (lr *LostRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	lr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint64(&lr.ID)
 	f.uint64(&lr.Lost)
 	f.idCond(ev.a.Options.SampleIDAll, &lr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // CommRecord (PERF_RECORD_COMM) indicates a change in the process name.
@@ -565,12 +597,13 @@ type CommRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (cr *CommRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (cr *CommRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	cr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint32(&cr.Pid, &cr.Tid)
 	f.string(&cr.NewName)
 	f.idCond(ev.a.Options.SampleIDAll, &cr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // commExecBit is PERF_RECORD_MISC_COMM_EXEC
@@ -594,13 +627,14 @@ type ExitRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (er *ExitRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (er *ExitRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	er.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint32(&er.Pid, &er.Ppid)
 	f.uint32(&er.Tid, &er.Ptid)
 	f.uint64(&er.Time)
 	f.idCond(ev.a.Options.SampleIDAll, &er.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // ThrottleRecord (PERF_RECORD_THROTTLE) indicates a throttle event.
@@ -613,13 +647,14 @@ type ThrottleRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (tr *ThrottleRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (tr *ThrottleRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	tr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint64(&tr.Time)
 	f.uint64(&tr.ID)
 	f.uint64(&tr.StreamID)
 	f.idCond(ev.a.Options.SampleIDAll, &tr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // UnthrottleRecord (PERF_RECORD_UNTHROTTLE) indicates an unthrottle event.
@@ -632,13 +667,14 @@ type UnthrottleRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (ur *UnthrottleRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (ur *UnthrottleRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	ur.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint64(&ur.Time)
 	f.uint64(&ur.ID)
 	f.uint64(&ur.StreamID)
 	f.idCond(ev.a.Options.SampleIDAll, &ur.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // ForkRecord (PERF_RECORD_FORK) indicates a fork event.
@@ -653,13 +689,14 @@ type ForkRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (fr *ForkRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (fr *ForkRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	fr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint32(&fr.Pid, &fr.Ppid)
 	f.uint32(&fr.Tid, &fr.Ptid)
 	f.uint64(&fr.Time)
 	f.idCond(ev.a.Options.SampleIDAll, &fr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // ReadRecord (PERF_RECORD_READ) indicates a read event.
@@ -672,12 +709,13 @@ type ReadRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (rr *ReadRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (rr *ReadRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	rr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint32(&rr.Pid, &rr.Tid)
 	f.count(&rr.Count, ev.a.CountFormat)
 	f.idCond(ev.a.Options.SampleIDAll, &rr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // ReadGroupRecord (PERF_RECORD_READ) indicates a read event on a group event.
@@ -690,12 +728,13 @@ type ReadGroupRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (rr *ReadGroupRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (rr *ReadGroupRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	rr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint32(&rr.Pid, &rr.Tid)
 	f.groupCount(&rr.GroupCount, ev.a.CountFormat)
 	f.idCond(ev.a.Options.SampleIDAll, &rr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // SampleRecord indicates a sample.
@@ -737,7 +776,7 @@ type SampleRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (sr *SampleRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (sr *SampleRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	sr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint64Cond(ev.a.SampleFormat.Identifier, &sr.Identifier)
@@ -754,7 +793,12 @@ func (sr *SampleRecord) DecodeFrom(raw *RawRecord, ev *Event) {
 	// in order to decode the sample.
 	if ev.a.SampleFormat.StreamID {
 		if sr.StreamID != ev.id {
-			ev = ev.groupByID[sr.StreamID]
+			newev := ev.groupByID[sr.StreamID]
+			if newev == nil {
+				ev.resetRing()
+				return ErrBadRecord
+			}
+			ev = newev
 		}
 	}
 
@@ -821,6 +865,7 @@ func (sr *SampleRecord) DecodeFrom(raw *RawRecord, ev *Event) {
 		}
 	}
 	f.uint64Cond(ev.a.SampleFormat.PhysicalAddress, &sr.PhysicalAddress)
+	return nil
 }
 
 // exactIPBit is PERF_RECORD_MISC_EXACT_IP
@@ -871,7 +916,7 @@ type SampleGroupRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (sr *SampleGroupRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (sr *SampleGroupRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	sr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint64Cond(ev.a.SampleFormat.Identifier, &sr.Identifier)
@@ -955,6 +1000,7 @@ func (sr *SampleGroupRecord) DecodeFrom(raw *RawRecord, ev *Event) {
 		}
 	}
 	f.uint64Cond(ev.a.SampleFormat.PhysicalAddress, &sr.PhysicalAddress)
+	return nil
 }
 
 // ExactIP indicates that sr.IP points to the actual instruction that
@@ -1027,7 +1073,7 @@ type Mmap2Record struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (mr *Mmap2Record) DecodeFrom(raw *RawRecord, ev *Event) {
+func (mr *Mmap2Record) DecodeFrom(raw *RawRecord, ev *Event) error {
 	mr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint32(&mr.Pid, &mr.Tid)
@@ -1040,6 +1086,7 @@ func (mr *Mmap2Record) DecodeFrom(raw *RawRecord, ev *Event) {
 	f.uint32(&mr.Prot, &mr.Flags)
 	f.string(&mr.Filename)
 	f.idCond(ev.a.Options.SampleIDAll, &mr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // Executable returns a boolean indicating whether the mapping is executable.
@@ -1070,7 +1117,7 @@ const (
 )
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (ar *AuxRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (ar *AuxRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	ar.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint64(&ar.Offset)
@@ -1079,6 +1126,7 @@ func (ar *AuxRecord) DecodeFrom(raw *RawRecord, ev *Event) {
 	f.uint64(&flag)
 	ar.Flags = AuxFlag(flag)
 	f.idCond(ev.a.Options.SampleIDAll, &ar.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // ItraceStartRecord (PERF_RECORD_ITRACE_START) indicates which process
@@ -1092,11 +1140,12 @@ type ItraceStartRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (ir *ItraceStartRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (ir *ItraceStartRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	ir.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint32(&ir.Pid, &ir.Tid)
 	f.idCond(ev.a.Options.SampleIDAll, &ir.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // LostSamplesRecord (PERF_RECORD_LOST_SAMPLES) indicates some number of
@@ -1109,11 +1158,12 @@ type LostSamplesRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (lr *LostSamplesRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (lr *LostSamplesRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	lr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint64(&lr.Lost)
 	f.idCond(ev.a.Options.SampleIDAll, &lr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // SwitchRecord (PERF_RECORD_SWITCH) indicates that a context switch has
@@ -1124,10 +1174,11 @@ type SwitchRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (sr *SwitchRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (sr *SwitchRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	sr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.idCond(ev.a.Options.SampleIDAll, &sr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // switchOutBit is PERF_RECORD_MISC_SWITCH_OUT
@@ -1158,11 +1209,12 @@ type SwitchCPUWideRecord struct {
 }
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (sr *SwitchCPUWideRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (sr *SwitchCPUWideRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	sr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint32(&sr.Pid, &sr.Tid)
 	f.idCond(ev.a.Options.SampleIDAll, &sr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // Out returns a boolean indicating whether the context switch was
@@ -1192,7 +1244,7 @@ type NamespacesRecord struct {
 // TODO(acln): check out *_NS_INDEX in perf_event.h
 
 // DecodeFrom implements the Record.DecodeFrom method.
-func (nr *NamespacesRecord) DecodeFrom(raw *RawRecord, ev *Event) {
+func (nr *NamespacesRecord) DecodeFrom(raw *RawRecord, ev *Event) error {
 	nr.RecordHeader = raw.Header
 	f := raw.fields()
 	f.uint32(&nr.Pid, &nr.Tid)
@@ -1204,6 +1256,7 @@ func (nr *NamespacesRecord) DecodeFrom(raw *RawRecord, ev *Event) {
 		f.uint64(&nr.Namespaces[i].Inode)
 	}
 	f.idCond(ev.a.Options.SampleIDAll, &nr.SampleID, ev.a.SampleFormat)
+	return nil
 }
 
 // Skid is an instruction pointer skid constraint.

--- a/record_amd64_test.go
+++ b/record_amd64_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build linux
+
 package perf_test
 
 import (

--- a/record_test.go
+++ b/record_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build linux
+
 package perf_test
 
 import (


### PR DESCRIPTION
This adds a few features and fixes on top of [the base perf package currently on review](https://go-review.googlesource.com/c/sys/+/168059).

Added
- OpenWithFlags() to pass custom flags to perf_event_open(2), necessary for managing our own event groups.
- HasRecord() to peek a ring buffer without blocking. Necessary to read multiple rings in parallel from a single goroutine.

Changes
- Add build tags

Fixes
- Fix bad handling of ring buffer memory.
- Add error checking to prevent crashes due to corrupted samples.
