### PR TITLE
Fix import of package in tests

### DIFF
--- a/count_test.go
+++ b/count_test.go
@@ -13,7 +13,8 @@ import (
 	"time"
 
 	"golang.org/x/sys/unix"
-	"golang.org/x/sys/unix/linux/perf"
+
+	"github.com/elastic/go-perf"
 )
 
 func TestCount(t *testing.T) {

--- a/group_test.go
+++ b/group_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/sys/unix/linux/perf"
+	"github.com/elastic/go-perf"
 )
 
 func TestGroup(t *testing.T) {

--- a/perf_example_test.go
+++ b/perf_example_test.go
@@ -13,7 +13,8 @@ import (
 	"runtime"
 
 	"golang.org/x/sys/unix"
-	"golang.org/x/sys/unix/linux/perf"
+
+	"github.com/elastic/go-perf"
 )
 
 func ExampleHardwareCounter_iPC() {

--- a/perf_test.go
+++ b/perf_test.go
@@ -19,7 +19,8 @@ import (
 	"unsafe"
 
 	"golang.org/x/sys/unix"
-	"golang.org/x/sys/unix/linux/perf"
+
+	"github.com/elastic/go-perf"
 )
 
 func TestOpen(t *testing.T) {

--- a/record_amd64_test.go
+++ b/record_amd64_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 	"unsafe"
 
-	"golang.org/x/sys/unix/linux/perf"
+	"github.com/elastic/go-perf"
 )
 
 func TestSampleUserRegisters(t *testing.T) {

--- a/record_test.go
+++ b/record_test.go
@@ -18,7 +18,8 @@ import (
 	"unsafe"
 
 	"golang.org/x/sys/unix"
-	"golang.org/x/sys/unix/linux/perf"
+
+	"github.com/elastic/go-perf"
 )
 
 func TestPoll(t *testing.T) {


### PR DESCRIPTION
The tests were failing, because the package was imported incorrectly.