### PR TITLE
Support BPF_LINK_CREATE to attach perf event

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -74,6 +74,16 @@ Tracepoints are also supported:
 	// ...
 	fmt.Printf("pid = %d, tid = %d\n", sr.Pid, sr.Tid)
 
+BPF programs
+
+BPF programs can be attached using SetBPF or SetBPFLink. SetBPFLink supports
+BPF cookies (Linux 5.15+), allowing a 64-bit value to be passed to the BPF
+program via bpf_get_attach_cookie():
+
+	link, err := ev.SetBPFLink(bpfProgFD, &perf.LinkOptions{Cookie: 0x1234})
+	// ...
+	defer link.Close()
+
 For more detailed information, see the examples, and man 2 perf_event_open.
 
 NOTE: this package is experimental and does not yet offer compatibility

--- a/link.go
+++ b/link.go
@@ -1,0 +1,115 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux
+
+package perf
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Link represents a BPF link attached to a perf event.
+type Link struct {
+	fd     int
+	closed bool
+}
+
+type bpfLinkCreatePerfEventAttr struct {
+	ProgFD     uint32
+	TargetFD   uint32
+	AttachType uint32
+	Flags      uint32
+	BPFCookie  uint64
+}
+
+// LinkOptions contains options for creating a BPF link.
+type LinkOptions struct {
+	// Cookie is accessible to the BPF program via bpf_get_attach_cookie().
+	Cookie uint64
+}
+
+// SetBPFLink attaches a BPF program to ev using the BPF link mechanism.
+// progfd is the file descriptor of the BPF program to attach.
+// opts may be nil for default options.
+func (ev *Event) SetBPFLink(progfd int, opts *LinkOptions) (*Link, error) {
+	if err := ev.ok(); err != nil {
+		return nil, err
+	}
+
+	perffd, err := ev.FD()
+	if err != nil {
+		return nil, err
+	}
+
+	var cookie uint64
+	if opts != nil {
+		cookie = opts.Cookie
+	}
+
+	attr := bpfLinkCreatePerfEventAttr{
+		ProgFD:     uint32(progfd),
+		TargetFD:   uint32(perffd),
+		AttachType: unix.BPF_PERF_EVENT,
+		Flags:      0,
+		BPFCookie:  cookie,
+	}
+
+	fd, err := bpfLinkCreate(&attr)
+	if err != nil {
+		return nil, fmt.Errorf("BPF_LINK_CREATE: %w", err)
+	}
+
+	return &Link{fd: fd}, nil
+}
+
+// FD returns the file descriptor of the BPF link.
+func (l *Link) FD() int {
+	return l.fd
+}
+
+// Close closes the BPF link, detaching the BPF program from the perf event.
+func (l *Link) Close() error {
+	if l == nil || l.closed {
+		return nil
+	}
+	l.closed = true
+	return unix.Close(l.fd)
+}
+
+func bpfLinkCreate(attr *bpfLinkCreatePerfEventAttr) (int, error) {
+	fd, _, errno := unix.Syscall(
+		unix.SYS_BPF,
+		unix.BPF_LINK_CREATE,
+		uintptr(unsafe.Pointer(attr)),
+		unsafe.Sizeof(*attr),
+	)
+	if errno != 0 {
+		return -1, os.NewSyscallError("bpf", errno)
+	}
+	return int(fd), nil
+}
+
+// ErrBPFLinkNotSupported is returned when BPF link creation is not supported.
+var ErrBPFLinkNotSupported = errors.New("BPF link not supported (requires Linux 5.15+)")
+
+// IsBPFLinkSupported returns true if the kernel supports BPF links for
+// perf events.
+func IsBPFLinkSupported() bool {
+	attr := bpfLinkCreatePerfEventAttr{
+		ProgFD:     ^uint32(0),
+		TargetFD:   ^uint32(0),
+		AttachType: unix.BPF_PERF_EVENT,
+	}
+	_, err := bpfLinkCreate(&attr)
+	if err == nil {
+		return true
+	}
+	return errors.Is(err, unix.EBADF)
+}

--- a/link_test.go
+++ b/link_test.go
@@ -1,0 +1,85 @@
+// Copyright 2019 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux
+
+package perf_test
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/elastic/go-perf"
+)
+
+func TestIsBPFLinkSupported(t *testing.T) {
+	supported := perf.IsBPFLinkSupported()
+	t.Logf("BPF link supported: %v", supported)
+}
+
+func TestSetBPFLink(t *testing.T) {
+	requires(t, paranoid(1), softwarePMU)
+
+	if !perf.IsBPFLinkSupported() {
+		t.Skip("BPF link not supported on this kernel")
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	attr := new(perf.Attr)
+	perf.PageFaults.Configure(attr)
+	attr.SetSamplePeriod(1)
+	attr.SampleFormat.IP = true
+
+	ev, err := perf.Open(attr, perf.CallingThread, perf.AnyCPU, nil)
+	if err != nil {
+		t.Fatalf("failed to open event: %v", err)
+	}
+	defer ev.Close()
+
+	_, err = ev.SetBPFLink(-1, &perf.LinkOptions{Cookie: 0x1234})
+	if err == nil {
+		t.Fatal("expected error for invalid program fd")
+	}
+	if !errors.Is(err, unix.EBADF) {
+		t.Logf("got error: %v (expected EBADF)", err)
+	}
+}
+
+func TestSetBPFLinkClosedEvent(t *testing.T) {
+	requires(t, paranoid(1), softwarePMU)
+
+	if !perf.IsBPFLinkSupported() {
+		t.Skip("BPF link not supported on this kernel")
+	}
+
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	attr := new(perf.Attr)
+	perf.PageFaults.Configure(attr)
+	attr.SetSamplePeriod(1)
+
+	ev, err := perf.Open(attr, perf.CallingThread, perf.AnyCPU, nil)
+	if err != nil {
+		t.Fatalf("failed to open event: %v", err)
+	}
+	ev.Close()
+
+	_, err = ev.SetBPFLink(0, nil)
+	if err == nil {
+		t.Fatal("expected error for closed event")
+	}
+}
+
+func TestLinkClose(t *testing.T) {
+	var l *perf.Link
+	if err := l.Close(); err != nil {
+		t.Errorf("Close on nil link returned error: %v", err)
+	}
+}


### PR DESCRIPTION
This is the prefered way to attach epbf program to kernel instead of legacy PERF_EVENT_IOC_SET_BPF. See https://docs.ebpf.io/linux/syscall/BPF_LINK_CREATE/

As a bonus point, this also allow user to attach a cookie to perf_event, and read it back via https://docs.ebpf.io/linux/helper-function/bpf_get_attach_cookie/